### PR TITLE
Proposed fix for issue #3

### DIFF
--- a/tasks/build-durandal.js
+++ b/tasks/build-durandal.js
@@ -68,6 +68,9 @@ module.exports = function (grunt) {
     //#region Private Methods
 
     function ensureRequireConfig(params) {
+        if (params.forceMain)
+            params.insertRequire.push("main");
+            
         params.insertRequire = _.uniq(params.insertRequire);
         params.includes = _.uniq(params.includes);
         params.excludes = _.uniq(params.excludes);
@@ -120,7 +123,8 @@ module.exports = function (grunt) {
                 include: [],
                 exclude: [],
                 insertRequire: [],
-                loglevel: "default"
+                loglevel: "default",
+                forceMain: true
             });
 
         ensureRequireConfig(params);


### PR DESCRIPTION
Remove the forced addition of "main" to the insertRequire param.  Since some projects may be assuming this behavior, this change would be a breaking change for them and would require them to configure the insertRequire themselves.  It may be better to wrap this in another param check to allow explicit suppression.

https://github.com/spatools/grunt-durandal/issues/3
