### PR TITLE
Stop insertRequire being passed to rjs if false

### DIFF
--- a/tasks/build-durandal.js
+++ b/tasks/build-durandal.js
@@ -70,8 +70,10 @@ module.exports = function (grunt) {
     function ensureRequireConfig(params) {
         if (params.includeMain)
             params.insertRequire.push("main");
-            
-        params.insertRequire = _.uniq(params.insertRequire);
+
+        if (params.insertRequire !== false)
+            params.insertRequire = _.uniq(params.insertRequire);
+
         params.includes = _.uniq(params.includes);
         params.excludes = _.uniq(params.excludes);
 


### PR DESCRIPTION
If insertRequire is set to false/null/undefined or has no value set, it appends the following to the built file:

````
require([""]);
````

This is due to the `_.uniq(params.insertRequire)` returning an empty array if passed any value that is not an array. This results in an empty array being passed to rjs which appends a require call to the built file if any array is passed in via `insertRequire`.

My change allows insertRequire to be explicitly set to false. This stops the array assignment, and prevents the empty require call from being added.